### PR TITLE
Add 'psycopg2-binary' to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,7 @@ pillow==11.1.0
 propcache==0.2.1
 protobuf==5.29.3
 psycopg2==2.9.10
+psycopg2-binary==2.9.10
 pyarrow==19.0.0
 pydantic==2.10.6
 pydantic_core==2.27.2


### PR DESCRIPTION
- 프로젝트에서 backend 모듈을 가져오지 못한 문제 해결
- `psycopg2-binary` 라이브러리 추가