### PR TITLE
Refactor: Restructure chat session and message storage per user

### DIFF
--- a/backend/accounts.py
+++ b/backend/accounts.py
@@ -1,11 +1,7 @@
-import streamlit as st
 import psycopg2
 import bcrypt
-from backend.config import DB_CONFIG
-
-# PostgreSQL 연결 함수
-def get_db_connection():
-    return psycopg2.connect(**DB_CONFIG, sslmode="require")
+import streamlit as st
+from backend.db import get_connection, release_connection  # Connection Pool 활용
 
 # 비밀번호 해싱
 def hash_password(password):
@@ -18,32 +14,71 @@ def verify_password(plain_password, hashed_password):
 
 # 사용자 등록
 def register_user(username, password):
+    """새 사용자를 데이터베이스에 추가"""
     hashed_password = hash_password(password)
-    try:
-        with get_db_connection() as conn, conn.cursor() as cur:
-            cur.execute("INSERT INTO users (username, password) VALUES (%s, %s)", (username, hashed_password))
-            conn.commit()
-            return True  # 회원가입 성공
-    except psycopg2.IntegrityError:
-        return False  # 중복 아이디 오류
+    conn = get_connection()
+    if conn:
+        try:
+            with conn.cursor() as cur:
+                cur.execute("INSERT INTO users (username, password) VALUES (%s, %s) RETURNING id;", 
+                            (username, hashed_password))
+                conn.commit()
+                return True  # 회원가입 성공
+        except psycopg2.IntegrityError:
+            return False  # 중복 아이디 오류
+        finally:
+            release_connection(conn)
 
-# 사용자 인증
+# 사용자 인증 (로그인)
 def authenticate(username, password):
-    with get_db_connection() as conn, conn.cursor() as cur:
-        cur.execute("SELECT password FROM users WHERE username = %s", (username,))
-        user_data = cur.fetchone()
-    
-    if user_data:
-        return verify_password(password, user_data[0])
-    return False
+    """사용자의 비밀번호를 검증하여 로그인 처리"""
+    conn = get_connection()
+    if conn:
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SELECT password FROM users WHERE username = %s AND is_active = TRUE", (username,))
+                user_data = cur.fetchone()
+            
+            if user_data:
+                return verify_password(password, user_data[0])  # 비밀번호 검증
+            return False
+        except Exception as e:
+            print(f"Error during authentication: {e}")
+            return False
+        finally:
+            release_connection(conn)
 
 # 로그인 처리 (세션 업데이트)
 def login_user(username):
+    """로그인 시 세션에 사용자 정보 저장"""
     st.session_state["authenticated"] = True
     st.session_state["user"] = username
+    st.success(f"{username}님, 로그인되었습니다.")
 
 # 로그아웃 처리
 def logout():
+    """로그아웃 시 세션 초기화"""
     st.session_state["authenticated"] = False
     st.session_state["user"] = None
     st.info("📢 로그아웃 되었습니다.")
+
+# 회원 탈퇴 (is_active = False 로 변경)
+def delete_user(username):
+    """회원 탈퇴 시 실제 데이터를 삭제하는 대신 is_active = False로 변경"""
+    conn = get_connection()
+    if conn:
+        try:
+            with conn.cursor() as cur:
+                cur.execute("UPDATE users SET is_active = FALSE WHERE username = %s", (username,))
+                conn.commit()
+                return True  # 탈퇴 성공
+        except Exception as e:
+            print(f"Error deleting user: {e}")
+            return False
+        finally:
+            release_connection(conn)
+
+# 로그인 상태 확인
+def is_authenticated():
+    """세션을 통해 현재 로그인 상태 확인"""
+    return st.session_state.get("authenticated", False)


### PR DESCRIPTION
## 관련 이슈
- 이슈번호(없을 시 생략)

## 작업 내용
- **사용자별 채팅 세션 및 메시지 저장 구조 변경**
  - `users`, `chat_sessions`, `chat_messages` 테이블을 설계 및 적용
  - 한 사용자가 여러 개의 채팅 세션을 가질 수 있도록 변경
  - 각 채팅 세션 안에서 사용자와 챗봇 간의 여러 메시지를 저장할 수 있도록 개선

- **DB 관련 기능 추가**
  - `create_chat_session(user_id)` → 새 채팅 세션 생성
  - `insert_chat_message(session_id, sender, message)` → 메시지 저장
  - `get_chat_history(session_id)` → 특정 채팅 세션 내 대화 기록 조회
  - `get_user_chat_sessions(user_id)` → 사용자의 전체 채팅 세션 목록 조회
  - `get_all_chat_sessions()` → 모든 사용자 채팅 목록 조회

- **DB 최적화**
  - `SimpleConnectionPool` 적용하여 DB 연결 풀링 최적화
  - `try-except` 추가하여 오류 발생 시 안전하게 처리

## 테스트 체크리스트
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
<!-- UI 작업한 경우 스크린샷 첨부해주세요 -->

## 참고 사항
- **이전과 다른 점**  
  - 기존 `interview_records` 테이블을 분리하여 **채팅 세션을 관리할 수 있도록 변경**
  - `user_id` → `chat_sessions` → `chat_messages` 관계를 적용하여 **구조적으로 확장 가능**  
  - 향후 **추가 기능 (예: 검색 기능 등) 확장이 용이함**  

- **추가해야 할 부분**
  - `chatbot.py`에서 대화 저장 로직(`insert_chat_message`)을 연동해야 함  
  - 프론트엔드에서 **채팅 세션을 생성하고 불러오는 기능을 추가해야 함**