### PR TITLE
feature: Add chat history deletion functions

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -130,3 +130,60 @@ def get_all_chat_sessions():
         finally:
             release_connection(conn)
     return sessions
+
+# 특정 채팅 세션의 대화 메시지 삭제
+def delete_chat_messages(session_id):
+    """특정 채팅 세션의 모든 메시지를 삭제"""
+    conn = get_connection()
+    if conn:
+        try:
+            with conn.cursor() as cur:
+                cur.execute("DELETE FROM chat_messages WHERE session_id = %s;", (session_id,))
+                conn.commit()
+                print(f"Chat messages for session {session_id} deleted successfully.")
+        except Exception as e:
+            print(f"Error deleting chat messages: {e}")
+        finally:
+            release_connection(conn)
+
+# 특정 채팅 세션과 모든 대화 내역 삭제
+def delete_chat_session(session_id):
+    """특정 채팅 세션의 메시지와 세션 정보를 삭제"""
+    conn = get_connection()
+    if conn:
+        try:
+            with conn.cursor() as cur:
+                # 1. 먼저 해당 세션의 메시지 삭제
+                cur.execute("DELETE FROM chat_messages WHERE session_id = %s;", (session_id,))
+                # 2. 채팅 세션 삭제
+                cur.execute("DELETE FROM chat_sessions WHERE id = %s;", (session_id,))
+                conn.commit()
+                print(f"Chat session {session_id} and its messages deleted successfully.")
+        except Exception as e:
+            print(f"Error deleting chat session: {e}")
+        finally:
+            release_connection(conn)
+
+# 특정 사용자의 모든 채팅 세션 및 대화 삭제
+def delete_all_user_sessions(user_id):
+    """특정 사용자의 모든 채팅 세션과 연관된 메시지를 삭제"""
+    conn = get_connection()
+    if conn:
+        try:
+            with conn.cursor() as cur:
+                # 1. 사용자의 모든 세션 ID 조회
+                cur.execute("SELECT id FROM chat_sessions WHERE user_id = %s;", (user_id,))
+                sessions = cur.fetchall()
+                
+                # 2. 각 세션의 메시지 삭제
+                for session in sessions:
+                    cur.execute("DELETE FROM chat_messages WHERE session_id = %s;", (session[0],))
+                
+                # 3. 사용자의 모든 세션 삭제
+                cur.execute("DELETE FROM chat_sessions WHERE user_id = %s;", (user_id,))
+                conn.commit()
+                print(f"All chat sessions and messages for user {user_id} deleted successfully.")
+        except Exception as e:
+            print(f"Error deleting all user chat sessions: {e}")
+        finally:
+            release_connection(conn)


### PR DESCRIPTION
## 관련 이슈
- 없음

## 작업 내용
- 특정 채팅 세션의 모든 메시지를 삭제하는 기능 추가 (`delete_chat_messages(session_id)`)
- 특정 채팅 세션과 모든 관련 메시지를 삭제하는 기능 추가 (`delete_chat_session(session_id)`)
- 특정 사용자의 모든 채팅 세션과 대화를 삭제하는 기능 추가 (`delete_all_user_sessions(user_id)`)
- 데이터베이스 연결 풀을 사용하여 안정적인 연결 관리

## 테스트 체크리스트
- [x] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
- 해당 없음

## 참고 사항
- 현재 `delete_all_user_sessions(user_id)`를 호출하면 사용자의 모든 채팅 기록이 삭제되므로, 사용 시 주의가 필요합니다.
- 추가적인 예외 처리나 로깅이 필요할 경우 피드백 부탁드립니다.
