### PR TITLE
Refactor : Refactor Chatbot & Restrict Access to Logged-in Users

### DIFF
--- a/backend/langchain_chatbot.py
+++ b/backend/langchain_chatbot.py
@@ -1,154 +1,119 @@
 import uuid
-from langchain_openai import ChatOpenAI, OpenAIEmbeddings
-from langchain_core.messages import HumanMessage
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import START, MessagesState, StateGraph
-from langchain_core.prompts import PromptTemplate
-from langchain_chroma import Chroma
 import streamlit as st
-from backend.config import (get_openai_key, 
-                            DEFAULT_MODEL, 
+from st_chat_message import message
+from backend.config import (get_openai_client,
+                            QUESTION_PROMPT,
+                            EVALUATION_PROMPT,
+                            retriever, 
                             BOT_AVATAR, USER_AVATAR)
 
-#streamlit api 키 호출
-key = get_openai_key()
-
-# OpenAI 모델 초기화
-model = ChatOpenAI(model=DEFAULT_MODEL, temperature=0.7, api_key= key)
-
-# RAG를 위한 vector store 연결 및 Embedding 설정
-embeddings = OpenAIEmbeddings()
-vector_store = Chroma(
-    persist_directory="my_vector_store", 
-    embedding_function=embeddings
-    )
-retriever = vector_store.as_retriever()
-
-# # 토픽 선택용 코드 추후 필요시 사용. 
-# # 면접 질문 생성
-# question_prompt = PromptTemplate(
-#     template="""주어진 문서를 기반으로 {topic} 면접 질문을 생성해 주세요. 
-#     문서 내용: {context}
-#     면접 질문:""",
-#     input_variables=["context", "topic"]  # "context"와 "topic"을 입력 변수로 추가
-# )
-
-# # 사용자가 원하는 주제 입력
-# topic = input("면접 질문을 생성할 주제를 입력하세요 (예: 파이썬): ")
-
-# # RAG를 이용하여 관련 문서 검색
-# retrieved_docs = retriever.invoke(topic)  # 사용자가 입력한 주제를 검색 쿼리로 사용
-# context = "\n".join([doc.page_content for doc in retrieved_docs])  # 검색된 문서에서 내용 가져오기
-
-# # RAG와 함께 질문 생성
-# question_chain = question_prompt | model
-# generated_question = question_chain.invoke({"context": context, "topic": topic}).content
-
-# print(f"Generated Question: {generated_question}")  # 생성된 질문 출력
 
 
-# 면접 질문 생성
-question_prompt = PromptTemplate(
-    template="""주어진 문서를 기반으로 파이썬 면접 질문을 하나만 생성해 주세요. 
-    문서 내용: {context}
-    면접 질문:""",
-    input_variables=["context"]  # "context"를 입력 변수로 추가
-)
+# Streamlit 세션 상태 초기화
+def initialize_session():
+    if "messages" not in st.session_state:
+        st.session_state.messages = []
 
-# 면접 챗봇 프롬프트 정의
-evaluation_prompt = PromptTemplate(
-    template="""
-    너는 파이썬 면접관 챗봇이야. 
-    지원자가 답변을 입력하면 아래의 문서를 참조해서 평가 및 모범답안을 제시를 수행해줘
-    
-    참고 문서:  
-    {context}
-    
-    질문: {question}
-    답변: {answer}
-    평가:
-    
-    """,
-    input_variables=["question", "answer"]
-)
+    if "generated_question" not in st.session_state:
+        # RAG를 이용하여 질문 생성을 위한 관련 문서 검색
+        retrieved_docs = retriever.invoke("파이썬 면접 질문 하나 생성해")  # 임시 검색 쿼리
+        context = "\n".join([doc.page_content for doc in retrieved_docs])  # 검색된 문서에서 내용 가져오기
+        
+        # 세션 상태에서 context 유지
+        st.session_state['context'] = context
+        
+        # 질문용 모델 체인 정의
+        question_chain = QUESTION_PROMPT | get_openai_client()
+        
+        # RAG와 함께 질문 생성
+        st.session_state.generated_question = question_chain.invoke({'context': context}).content
 
-# RAG를 이용하여 질문 생성을 위한 관련 문서 검색
-retrieved_docs = retriever.invoke("파이썬 면접 질문 하나 생성해")  # 임시로 사용한 검색 쿼리
-context = "\n".join([doc.page_content for doc in retrieved_docs])  # 검색된 문서에서 내용 가져오기
 
-#질문용 모델 체인 정의
-question_chain = question_prompt | model
-
-# RAG와 함께 질문 생성
-generated_question = question_chain.invoke({"context": context}).content
 
 # RAG를 이용하여 피드백을 위해 검색된 문서 가져오기
-retrieved_docs = retriever.invoke(generated_question)
-context = "\n".join([doc.page_content for doc in retrieved_docs])
-
-#평가용 모델 체인 정의 
-evaluation_chain = evaluation_prompt | model
-
-
-# 그래프 정의
-workflow = StateGraph(state_schema=MessagesState)
-
-def call_model(state: MessagesState):
-    response = evaluation_chain.invoke({
-        "question": generated_question,
-        "answer": state["messages"][-1].content,
-        "context": context
-    })
-    return {"messages": [response]}
-
-workflow.add_edge(START, "chain")
-workflow.add_node("chain", call_model)
-
-memory = MemorySaver()
-app = workflow.compile(checkpointer=memory)
+def feedback_documents():
+    if "generated_question" in st.session_state:
+        retrieved_docs = retriever.invoke(st.session_state.generated_question)
+        st.session_state.feedback_context = "\n".join([doc.page_content for doc in retrieved_docs])
 
 
-while True :
-    # 질문 생성
-    generated_question = question_chain.invoke({}).content
-    print(f"Generated Question: {generated_question}")  # 생성된 질문 출력
-    # 대화 세션 관리
-    thread_id = uuid.uuid4()
-    config = {"configurable": {"thread_id": thread_id}}
-    # 사용자 입력 처리
-    contents = input("답변 입력: ")
-    if contents == "exit":
-        sys.exit()
-    input_message = HumanMessage(content=contents)
-    for event in app.stream({"messages": [input_message]}, config, stream_mode="values"):
-        event["messages"][-1].pretty_print()
-    print("")
+def initialize_evaluation_workflow():
+    """ 평가용 모델 체인을 기반으로 LangGraph 워크플로우 초기화 """
+    # 그래프 정의
+    workflow = StateGraph(state_schema=MessagesState)
 
+    # 모델 평가 함수 정의
+    def call_model(state: MessagesState):
+        evaluation_chain = EVALUATION_PROMPT | get_openai_client()
+        response = evaluation_chain.invoke({
+            "question": st.session_state.get("generated_question", ""),
+            "answer": state["messages"][-1].content,
+            "context": st.session_state.get("context", "")
+        })
+        return {"messages": [response]}
+
+    # 노드 및 엣지 추가
+    workflow.add_node("chain", call_model)
+    workflow.add_edge(START, "chain")
+
+    # 체크포인트 메모리 저장
+    memory = MemorySaver()
+    
+    # 워크플로우 컴파일
+    app = workflow.compile(checkpointer=memory)
+    
+    return app
+
+
+# 채팅 기록 출력 함수
+def display_chat_history():
+    for i, msg in enumerate(st.session_state.messages):
+        is_user = msg["role"] == "user"
+        message(msg["content"], is_user=is_user, key=f"msg_{i}", logo=USER_AVATAR if is_user else BOT_AVATAR)
 
 
 
+def generate_question():
+    """ 사용자의 답변 후 새로운 질문을 생성하는 함수 """
+    question_chain = QUESTION_PROMPT | get_openai_client()
 
+    # 새로운 질문 생성
+    generated_question = question_chain.invoke(
+        {"context": st.session_state.get("context", "")}
+    ).content
 
+    # 세션 상태 업데이트
+    st.session_state.generated_question = generated_question
+    st.session_state.messages.append({"role": "assistant", "content": generated_question})
 
+def handle_user_input():
+    """ 사용자 입력을 처리하는 함수 """
+    if prompt := st.chat_input("답변을 입력하세요..."):
 
-# # 토픽 선택용 코드 추후 필요시 사용. 
-# # 면접 질문 생성
-# question_prompt = PromptTemplate(
-#     template="""주어진 문서를 기반으로 {topic} 면접 질문을 생성해 주세요. 
-#     문서 내용: {context}
-#     면접 질문:""",
-#     input_variables=["context", "topic"]  # "context"와 "topic"을 입력 변수로 추가
-# )
+        # 사용자 입력 저장 및 출력
+        st.session_state.messages.append({"role": "user", "content": prompt})
+        message(prompt, is_user=True, key=f"user_{len(st.session_state.messages)}", logo=USER_AVATAR)
 
-# # 사용자가 원하는 주제 입력
-# topic = input("면접 질문을 생성할 주제를 입력하세요 (예: 파이썬): ")
+        # LangGraph 워크플로우를 실행하여 RAG 검색 및 응답 생성
+        thread_id = uuid.uuid4()
+        config = {"configurable": {"thread_id": thread_id}}
 
-# # RAG를 이용하여 관련 문서 검색
-# retrieved_docs = retriever.invoke(topic)  # 사용자가 입력한 주제를 검색 쿼리로 사용
-# context = "\n".join([doc.page_content for doc in retrieved_docs])  # 검색된 문서에서 내용 가져오기
+        input_message = {"role": "user", "content": prompt}
+        
+        # LangGraph 평가 워크플로우 실행
+        if "app" not in st.session_state:
+            st.session_state.app = initialize_evaluation_workflow()
+        
+        # AI 평가 수행
+        for event in st.session_state.app.stream({"messages": [input_message]}, config, stream_mode="values"):
+            response = event["messages"][-1].content
 
-# # RAG와 함께 질문 생성
-# question_chain = question_prompt | model
-# generated_question = question_chain.invoke({"context": context, "topic": topic}).content
+            # ✅ 중복 방지: 동일한 응답이 있는지 확인
+            if not any(msg["content"] == response for msg in st.session_state.messages):
+                st.session_state.messages.append({"role": "assistant", "content": response})
+                message(response, is_user=False, key=f"assistant_{len(st.session_state.messages)}", logo=BOT_AVATAR)
 
-# print(f"Generated Question: {generated_question}")  # 생성된 질문 출력
+        # ✅ 면접 지속 여부 선택 버튼 추가
+        st.session_state.show_continue_button = True

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -11,3 +11,16 @@
 로깅(Logging) 함수
 - 에러 발생 시 원인을 쉽게 추적할 수 있도록 로그를 남길 때 유용
 '''
+
+import streamlit as st
+from backend.accounts import logout
+
+def show_sidebar():
+    """로그인 상태일 때 모든 페이지에 로그아웃 버튼 표시"""
+    if st.session_state.get("authenticated", False):
+        with st.sidebar:
+            st.write(f"✅ 로그인 상태: {st.session_state['user']}님")
+            if st.button("로그아웃"):
+                logout()
+                st.success('로그아웃 되었습니다.')
+                st.rerun()

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import streamlit as st
-from backend.accounts import authenticate, register_user, login_user, logout
+from backend.accounts import authenticate, register_user, login_user
+from backend.utils import show_sidebar
 
 
 # 세션 상태 초기화
@@ -21,6 +22,8 @@ if not st.session_state["authenticated"]:
 
         if st.button("로그인"):
             if authenticate(input_username, input_password):
+                st.session_state["authenticated"] = True  # 로그인 상태 유지 
+                st.session_state["username"] = input
                 login_user(input_username)  # 세션 상태 업데이트
                 st.success(f"🎉 환영합니다, {input_username}님!")
                 st.rerun()  # 화면 새로고침하여 UI 반영
@@ -38,5 +41,6 @@ if not st.session_state["authenticated"]:
                 st.error("❌ 이미 존재하는 아이디입니다.")
 
 else:
-    st.sidebar.button("로그아웃", on_click=logout)
-    st.write(f"✅ 로그인 상태: {st.session_state['user']}님")
+    st.write(f"✅ 로그인 상태: {st.session_state['user']}님, 반갑습니다!")
+
+show_sidebar()

--- a/pages/chat.py
+++ b/pages/chat.py
@@ -7,10 +7,26 @@ from backend.langchain_chatbot import (
     initialize_evaluation_workflow,
     generate_question
 )
+from backend.db import create_chat_session
+from backend.utils import show_sidebar
+
 
 # Streamlit UI 실행 함수
 st.set_page_config(page_title="AI 면접 도우미 챗봇")
 st.title("AI 면접 도우미 챗봇")
+show_sidebar()
+
+
+# 로그인 확인
+if "authenticated" not in st.session_state or not st.session_state["authenticated"]:
+    st.warning("🚨 채팅을 사용하려면 먼저 로그인하세요.")
+    st.stop()  # 로그인 안 했으면 실행 중지
+
+
+user_id = st.session_state["username"]  # 로그인한 사용자 ID
+session_id = create_chat_session(user_id)  # 새로운 세션 생성
+
+
 
 # 세션 상태 초기화
 initialize_session()

--- a/pages/chat.py
+++ b/pages/chat.py
@@ -1,9 +1,57 @@
 import streamlit as st
-from backend.chatbot import initialize_session, display_chat_history, handle_user_input
+from backend.langchain_chatbot import (
+    initialize_session,
+    display_chat_history,
+    handle_user_input,
+    feedback_documents,
+    initialize_evaluation_workflow,
+    generate_question
+)
 
+# Streamlit UI 실행 함수
+st.set_page_config(page_title="AI 면접 도우미 챗봇")
 st.title("AI 면접 도우미 챗봇")
 
-# 챗 초기화 및 UI 표시
+# 세션 상태 초기화
 initialize_session()
+
+# 피드백 문서 검색
+feedback_documents()
+
+# LangGraph 평가 워크플로우 초기화 (세션에 저장)
+if "app" not in st.session_state:
+    st.session_state.app = initialize_evaluation_workflow()
+
+# 채팅 기록 출력
 display_chat_history()
+
+# 면접 시작 버튼
+if "interview_started" not in st.session_state:
+    st.session_state.interview_started = False
+
+if not st.session_state.interview_started:
+    if st.button("면접 시작하기"):
+        st.session_state.interview_started = True
+        st.session_state.show_continue_button = False  # 새 질문 생성 시 버튼 숨김
+        generate_question()  # 첫 질문 생성
+
+# 사용자 입력 받기
 handle_user_input()
+
+# 면접 지속 여부 버튼 표시
+if st.session_state.get("show_continue_button", False):
+    st.write("면접을 계속하시겠습니까?")
+    col1, col2 = st.columns(2)
+    
+    with col1:
+        if st.button("계속 진행"):
+            st.session_state.show_continue_button = False  # 버튼 숨기기
+            generate_question()  # 다음 질문 생성
+
+    with col2:
+        if st.button("종료하고 저장"):
+            st.write("면접을 종료합니다.")
+            st.session_state.interview_started = False
+            st.session_state.show_continue_button = False  # 버튼 숨김
+            st.session_state.chat_history = []  # 채팅 기록 초기화
+            st.rerun()  # 페이지 새로고침


### PR DESCRIPTION
## 관련 이슈
- 없음

## 작업 내용
- Chatbot
  - LangChain 챗봇이 Steamlit에서 작동하도록 코드 구조화
  - Chatbot 실행 구조
    - 면접 시작하기 누르기 → 챗봇 : 질문 → 사용자 : 답변  →  챗봇 : 평가 및 모범답안 제공  → 면접 계속 진행 유무 질문
      - 계속 진행 : 새로운 질문
      - 종료 : '면접을 종료합니다.' 메세지 출력
- Login
  - 모든 화면의 사이드바 UI에 로그인시 로그아웃을 추가
  - 로그인한 사용자만 Chatbot을 이용할 수 있도록 변경

## 테스트 체크리스트
- [ ] 로컬 테스트 완료
- [x] 코드 컨벤션 준수
- [x] 불필요한 코드 제거

## 스크린샷
![image](https://github.com/user-attachments/assets/acf9fde3-e146-4e38-b64f-edec29f47110)
![image](https://github.com/user-attachments/assets/1f812f1d-7a76-48d7-b151-cfde738dc01a)


## 참고 사항
- 챗봇은 DB의 내용이 추가되고 나서 chatbot test파일 생성하고 로컬 테스트 진행할 예정
- Chatbot UI에서 면접 종료시 DB에 저장하고 새로운 면접을 실행할 수 있도록 수정 예정